### PR TITLE
Sistema de Gestión de Estado de Issues en Peticiones de Cambio

### DIFF
--- a/backend/src/controllers/peticionCambioController.js
+++ b/backend/src/controllers/peticionCambioController.js
@@ -20,10 +20,12 @@ const obtenerTodasPeticiones = async (req, res) => {
         rc.DECISION,
         rc.OBSERVACIONES,
         rc.RESPONSABLE_TECNICO,
+        CONCAT(COALESCE(resp.NOMBRES, ''), ' ', COALESCE(resp.APELLIDOS, '')) as RESPONSABLE_TECNICO_NOMBRE,
         rc.FECHA_DECISION,
         rc.FECHA_SOLICITUD,
         rc.FECHA_ENTREGA,
         rc.ESTADO,
+        rc.ESTADO_ISSUE,
         rc.APROBACIONES_COUNT,
         sc.MODULO_AFECTADO,
         sc.TIPO_SOLICITUD,
@@ -35,6 +37,7 @@ const obtenerTodasPeticiones = async (req, res) => {
       FROM recepcion_cambio rc
       LEFT JOIN solicitud_cambio sc ON rc.SECUENCIAL_CAMBIO = sc.SECUENCIAL
       LEFT JOIN usuario u ON sc.SECUENCIAL_USUARIO = u.SECUENCIAL
+      LEFT JOIN usuario resp ON rc.RESPONSABLE_TECNICO = resp.SECUENCIAL
       ORDER BY rc.FECHA_DECISION DESC`
     );
 
@@ -469,11 +472,16 @@ const obtenerPeticionPorId = async (req, res) => {
         u.CORREO,
         creador.NOMBRES as CREADOR_NOMBRES,
         creador.APELLIDOS as CREADOR_APELLIDOS,
-        creador.SECUENCIAL as CREADOR_ID
+        creador.SECUENCIAL as CREADOR_ID,
+        finalizador.NOMBRES as FINALIZADOR_NOMBRES,
+        finalizador.APELLIDOS as FINALIZADOR_APELLIDOS,
+        CONCAT(COALESCE(resp.NOMBRES, ''), ' ', COALESCE(resp.APELLIDOS, '')) as RESPONSABLE_TECNICO_NOMBRE
       FROM recepcion_cambio rc
       LEFT JOIN solicitud_cambio sc ON rc.SECUENCIAL_CAMBIO = sc.SECUENCIAL
       LEFT JOIN usuario u ON sc.SECUENCIAL_USUARIO = u.SECUENCIAL
       LEFT JOIN usuario creador ON rc.SECUENCIAL_CREADOR = creador.SECUENCIAL
+      LEFT JOIN usuario finalizador ON rc.SECUENCIAL_USUARIO_FINALIZACION = finalizador.SECUENCIAL
+      LEFT JOIN usuario resp ON rc.RESPONSABLE_TECNICO = resp.SECUENCIAL
       WHERE rc.SECUENCIAL = ?`,
       [id]
     );
@@ -700,11 +708,104 @@ const crearPeticionCambioDirecta = async (req, res) => {
   }
 };
 
+// Actualizar estado del issue de una petición
+const actualizarEstadoIssue = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { estadoIssue, urlGithubIssue, usuarioNombre } = req.body;
+    const usuarioId = req.user?.id || req.body.usuarioId;
+
+    if (!['Pendiente', 'Finalizado'].includes(estadoIssue)) {
+      return res.status(400).json({ error: 'Estado de issue inválido' });
+    }
+
+    // Obtener la petición para validar el responsable técnico y estado actual
+    const [peticiones] = await pool.execute(
+      `SELECT rc.RESPONSABLE_TECNICO, rc.ESTADO_ISSUE, u.NOMBRES, u.APELLIDOS 
+       FROM recepcion_cambio rc
+       LEFT JOIN usuario u ON rc.RESPONSABLE_TECNICO = u.SECUENCIAL
+       WHERE rc.SECUENCIAL = ?`,
+      [id]
+    );
+
+    if (peticiones.length === 0) {
+      return res.status(404).json({ error: 'Petición no encontrada' });
+    }
+
+    const peticion = peticiones[0];
+    const nombreResponsable = peticion.NOMBRES && peticion.APELLIDOS 
+      ? `${peticion.NOMBRES} ${peticion.APELLIDOS}` 
+      : 'Desconocido';
+
+    // Validar que no se pueda cambiar desde "Finalizado"
+    if (peticion.ESTADO_ISSUE === 'Finalizado') {
+      return res.status(403).json({ 
+        error: 'No se puede cambiar el estado de un issue que ya está finalizado' 
+      });
+    }
+
+    // Validar que solo el responsable técnico pueda marcar como finalizado
+    if (estadoIssue === 'Finalizado' && peticion.RESPONSABLE_TECNICO && peticion.RESPONSABLE_TECNICO !== usuarioId) {
+      return res.status(403).json({ 
+        error: `Solo el responsable técnico (${nombreResponsable}) puede marcar el issue como finalizado` 
+      });
+    }
+
+    let query = `UPDATE recepcion_cambio SET ESTADO_ISSUE = ?`;
+    const params = [estadoIssue];
+
+    // Si se marca como finalizado, guardar fecha, usuario y URL
+    if (estadoIssue === 'Finalizado') {
+      query += `, FECHA_FINALIZACION_ISSUE = NOW()`;
+      
+      if (usuarioId) {
+        query += `, SECUENCIAL_USUARIO_FINALIZACION = ?`;
+        params.push(usuarioId);
+      }
+      
+      if (urlGithubIssue) {
+        query += `, URL_GITHUB_ISSUE = ?`;
+        params.push(urlGithubIssue);
+      }
+    } else if (estadoIssue === 'Pendiente') {
+      // Si se vuelve a marcar como pendiente, limpiar datos de finalización
+      query += `, FECHA_FINALIZACION_ISSUE = NULL, SECUENCIAL_USUARIO_FINALIZACION = NULL`;
+    }
+
+    query += ` WHERE SECUENCIAL = ?`;
+    params.push(id);
+
+    const [result] = await pool.execute(query, params);
+
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'Petición no encontrada' });
+    }
+
+    res.json({
+      success: true,
+      message: 'Estado del issue actualizado correctamente',
+      data: { 
+        SECUENCIAL: id, 
+        ESTADO_ISSUE: estadoIssue,
+        FECHA_FINALIZACION_ISSUE: estadoIssue === 'Finalizado' ? new Date() : null,
+        URL_GITHUB_ISSUE: urlGithubIssue || null
+      }
+    });
+  } catch (error) {
+    console.error('❌ Error al actualizar estado del issue:', error);
+    res.status(500).json({ 
+      error: 'Error al actualizar estado del issue', 
+      details: error.message 
+    });
+  }
+};
+
 module.exports = {
   obtenerTodasPeticiones,
   aprobarPeticionCambio,
   rechazarPeticionCambio,
   obtenerPeticionPorId,
-  crearPeticionCambioDirecta
+  crearPeticionCambioDirecta,
+  actualizarEstadoIssue
 };
 

--- a/backend/src/routes/peticionCambioRoutes.js
+++ b/backend/src/routes/peticionCambioRoutes.js
@@ -5,7 +5,8 @@ const {
   aprobarPeticionCambio,
   rechazarPeticionCambio,
   obtenerPeticionPorId,
-  crearPeticionCambioDirecta
+  crearPeticionCambioDirecta,
+  actualizarEstadoIssue
 } = require('../controllers/peticionCambioController');
 
 // Ruta para obtener todas las peticiones de cambio (admin)
@@ -22,6 +23,9 @@ router.post('/:id/aprobar', aprobarPeticionCambio);
 
 // Ruta para rechazar una petición de cambio (admin aprobador)
 router.post('/:id/rechazar', rechazarPeticionCambio);
+
+// Ruta para actualizar estado del issue
+router.put('/:id/estado-issue', actualizarEstadoIssue);
 
 module.exports = router;
 

--- a/src/pages/Admin/PeticionesCambioAdmin/PeticionesCambioAdmin.css
+++ b/src/pages/Admin/PeticionesCambioAdmin/PeticionesCambioAdmin.css
@@ -458,3 +458,38 @@
   }
 }
 
+/* Estilos para botones de estado issue */
+.btn-estado-issue {
+  transition: all 0.3s ease;
+}
+
+.btn-estado-issue:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.btn-estado-issue.active {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+/* Estilos para badges de estado issue en tabla */
+.status-success {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.status-warning {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+/* Estilos para botones deshabilitados */
+.btn-estado-issue:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-estado-issue:disabled:hover {
+  transform: none;
+  box-shadow: none;
+}

--- a/src/pages/Admin/PeticionesCambioAdmin/PeticionesCambioAdmin.js
+++ b/src/pages/Admin/PeticionesCambioAdmin/PeticionesCambioAdmin.js
@@ -342,6 +342,68 @@ const PeticionesCambioAdmin = () => {
     return selectedPeticion.rechazos.some(r => r.SECUENCIAL_ADMIN === user.id);
   };
 
+  const cambiarEstadoIssue = async (nuevoEstado, urlGithub = null) => {
+    if (!selectedPeticion || selectedPeticion.ESTADO !== 'Completado') {
+      setMessage({ type: 'error', text: 'Solo puedes cambiar el estado del issue cuando la petición está completada' });
+      return;
+    }
+
+    // Validar que solo el responsable técnico pueda cambiar el estado
+    if (nuevoEstado === 'Finalizado' && selectedPeticion.RESPONSABLE_TECNICO !== user?.id) {
+      setMessage({ type: 'error', text: `Solo el responsable técnico (${selectedPeticion.RESPONSABLE_TECNICO_NAME}) puede marcar el issue como finalizado` });
+      return;
+    }
+
+    // Si se marca como finalizado y no hay URL, pedir al usuario que la ingrese
+    if (nuevoEstado === 'Finalizado' && !urlGithub && !selectedPeticion.URL_GITHUB_ISSUE) {
+      const url = window.prompt('Ingresa la URL del issue en GitHub (ej: https://github.com/usuario/repo/issues/123):');
+      if (!url) {
+        setMessage({ type: 'warning', text: 'Se requiere la URL del issue para marcar como finalizado' });
+        return;
+      }
+      urlGithub = url;
+    }
+
+    try {
+      const requestBody = { 
+        estadoIssue: nuevoEstado,
+        usuarioId: user?.id,
+        usuarioNombre: user?.nombres
+      };
+
+      if (nuevoEstado === 'Finalizado' && urlGithub) {
+        requestBody.urlGithubIssue = urlGithub;
+      }
+
+      const response = await fetch(`${API_URL}/api/peticiones-cambio/${selectedPeticion.SECUENCIAL}/estado-issue`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(requestBody)
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        setMessage({ type: 'success', text: `Estado del issue actualizado a: ${nuevoEstado}` });
+        // Actualizar el estado local
+        setSelectedPeticion({
+          ...selectedPeticion,
+          ESTADO_ISSUE: nuevoEstado,
+          FECHA_FINALIZACION_ISSUE: nuevoEstado === 'Finalizado' ? new Date() : null,
+          URL_GITHUB_ISSUE: urlGithub || selectedPeticion.URL_GITHUB_ISSUE
+        });
+        // Recargar peticiones para reflejar el cambio en la tabla
+        cargarPeticiones();
+      } else {
+        setMessage({ type: 'error', text: data.error || 'Error al actualizar el estado del issue' });
+      }
+    } catch (error) {
+      console.error('Error:', error);
+      setMessage({ type: 'error', text: 'Error al actualizar el estado del issue' });
+    }
+  };
+
   const generarIssueGitHub = () => {
     if (!selectedPeticion || selectedPeticion.ESTADO !== 'Completado') return '';
 
@@ -471,6 +533,7 @@ ${selectedPeticion.OBSERVACIONES || 'N/A'}
                 <th>Tipo</th>
                 <th>Prioridad</th>
                 <th>Estado</th>
+                <th>Issue</th>
                 <th>Aprobaciones</th>
                 <th>Fecha</th>
                 <th>Acciones</th>
@@ -511,6 +574,15 @@ ${selectedPeticion.OBSERVACIONES || 'N/A'}
                     <span className={`status-badge ${getEstadoBadgeClass(peticion.ESTADO)}`}>
                       {peticion.ESTADO}
                     </span>
+                  </td>
+                  <td>
+                    {peticion.ESTADO === 'Completado' ? (
+                      <span className={`status-badge ${peticion.ESTADO_ISSUE === 'Finalizado' ? 'status-success' : 'status-warning'}`}>
+                        {peticion.ESTADO_ISSUE || 'Pendiente'}
+                      </span>
+                    ) : (
+                      <span style={{ color: '#999' }}>-</span>
+                    )}
                   </td>
                   <td>
                     {peticion.ESTADO === 'Pendiente Crear' ? (
@@ -587,6 +659,110 @@ ${selectedPeticion.OBSERVACIONES || 'N/A'}
               <div className="detalle-item">
                 <strong>Estado:</strong> {selectedPeticion.ESTADO}
               </div>
+
+              {selectedPeticion.ESTADO === 'Completado' && (
+                <div className="detalle-item" style={{ backgroundColor: '#eff6ff', padding: '1rem', borderRadius: '6px', border: '1px solid #bfdbfe', marginTop: '1rem' }}>
+                  <strong style={{ display: 'block', marginBottom: '0.75rem' }}>🔗 Estado del Issue</strong>
+                  
+                  {selectedPeticion.ESTADO_ISSUE === 'Finalizado' && (
+                    <div style={{ 
+                      backgroundColor: '#dcfce7', 
+                      border: '1px solid #86efac', 
+                      color: '#166534', 
+                      padding: '0.75rem', 
+                      borderRadius: '4px', 
+                      marginBottom: '0.75rem',
+                      fontSize: '0.9rem'
+                    }}>
+                      ✅ Este issue ha sido finalizado y no se puede cambiar su estado
+                    </div>
+                  )}
+                  
+                  {selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id && (
+                    <div style={{ 
+                      backgroundColor: '#fef3c7', 
+                      border: '1px solid #fcd34d', 
+                      color: '#92400e', 
+                      padding: '0.75rem', 
+                      borderRadius: '4px', 
+                      marginBottom: '0.75rem',
+                      fontSize: '0.9rem'
+                    }}>
+                      🔒 Solo el responsable técnico (<strong>{selectedPeticion.RESPONSABLE_TECNICO_NAME}</strong>) puede finalizar el issue
+                    </div>
+                  )}
+                  
+                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+                    <button
+                      type="button"
+                      className={`btn-estado-issue ${selectedPeticion.ESTADO_ISSUE === 'Pendiente' ? 'active' : ''}`}
+                      onClick={() => cambiarEstadoIssue('Pendiente')}
+                      disabled={selectedPeticion.ESTADO_ISSUE === 'Finalizado' || (selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id)}
+                      style={{
+                        padding: '0.5rem 1rem',
+                        backgroundColor: selectedPeticion.ESTADO_ISSUE === 'Pendiente' ? '#f59e0b' : '#e5e7eb',
+                        color: selectedPeticion.ESTADO_ISSUE === 'Pendiente' ? 'white' : '#374151',
+                        border: 'none',
+                        borderRadius: '6px',
+                        cursor: selectedPeticion.ESTADO_ISSUE === 'Finalizado' || (selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id) ? 'not-allowed' : 'pointer',
+                        fontSize: '0.9rem',
+                        fontWeight: '600',
+                        transition: 'all 0.2s',
+                        opacity: selectedPeticion.ESTADO_ISSUE === 'Finalizado' || (selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id) ? '0.6' : '1'
+                      }}
+                    >
+                      ⏳ Pendiente
+                    </button>
+                    <button
+                      type="button"
+                      className={`btn-estado-issue ${selectedPeticion.ESTADO_ISSUE === 'Finalizado' ? 'active' : ''}`}
+                      onClick={() => cambiarEstadoIssue('Finalizado')}
+                      disabled={selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id}
+                      style={{
+                        padding: '0.5rem 1rem',
+                        backgroundColor: selectedPeticion.ESTADO_ISSUE === 'Finalizado' ? '#10b981' : '#e5e7eb',
+                        color: selectedPeticion.ESTADO_ISSUE === 'Finalizado' ? 'white' : '#374151',
+                        border: 'none',
+                        borderRadius: '6px',
+                        cursor: selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id ? 'not-allowed' : 'pointer',
+                        fontSize: '0.9rem',
+                        fontWeight: '600',
+                        transition: 'all 0.2s',
+                        opacity: selectedPeticion.RESPONSABLE_TECNICO && selectedPeticion.RESPONSABLE_TECNICO !== user?.id ? '0.6' : '1'
+                      }}
+                    >
+                      ✅ Finalizado
+                    </button>
+                  </div>
+                  <div style={{ fontSize: '0.9rem', color: '#666', marginTop: '0.5rem' }}>
+                    <p style={{ margin: '0.25rem 0' }}>
+                      <strong>Estado:</strong> {selectedPeticion.ESTADO_ISSUE || 'Pendiente'}
+                    </p>
+                    <p style={{ margin: '0.25rem 0' }}>
+                      <strong>Responsable técnico:</strong> {selectedPeticion.RESPONSABLE_TECNICO_NOMBRE || 'No asignado'}
+                    </p>
+                    {selectedPeticion.FECHA_FINALIZACION_ISSUE && (
+                      <p style={{ margin: '0.25rem 0' }}>
+                        <strong>Fecha de finalización:</strong> {new Date(selectedPeticion.FECHA_FINALIZACION_ISSUE).toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                      </p>
+                    )}
+                    {selectedPeticion.FINALIZADOR_NOMBRES && (
+                      <p style={{ margin: '0.25rem 0' }}>
+                        <strong>Marcado como finalizado por:</strong> {selectedPeticion.FINALIZADOR_NOMBRES} {selectedPeticion.FINALIZADOR_APELLIDOS}
+                      </p>
+                    )}
+                    {selectedPeticion.URL_GITHUB_ISSUE && (
+                      <p style={{ margin: '0.25rem 0' }}>
+                        <strong>URL del Issue:</strong> 
+                        <a href={selectedPeticion.URL_GITHUB_ISSUE} target="_blank" rel="noopener noreferrer" style={{ color: '#3b82f6', marginLeft: '0.5rem', textDecoration: 'none' }}>
+                          {selectedPeticion.URL_GITHUB_ISSUE}
+                        </a>
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
               <div className="detalle-item">
                 <strong>Aprobaciones:</strong> {selectedPeticion.APROBACIONES_COUNT || 0}/2
               </div>


### PR DESCRIPTION
## Resumen
Implementación de sistema formal de seguimiento y auditoría para el estado de issues en peticiones de cambio. Los responsables técnicos pueden marcar issues como "Finalizado" (inmutable) con registro automático de fecha, usuario y URL de GitHub.

## Cambios Realizados

**Backend**
* Nuevas columnas en `recepcion_cambio`: `ESTADO_ISSUE` (ENUM), `FECHA_FINALIZACION_ISSUE`, `SECUENCIAL_USUARIO_FINALIZACION`, `URL_GITHUB_ISSUE`
* Conversión de `RESPONSABLE_TECNICO` de VARCHAR a INT con FK a `usuario.SECUENCIAL`
* Endpoint `PUT /api/peticiones-cambio/:id/estado-issue` con validaciones de permisos e inmutabilidad
* Queries mejorados con JOINs para traer nombres de responsables

**Frontend**
* Nueva sección "🔗 Estado del Issue" con botones Pendiente/Finalizado
* Validaciones visuales: botón "Pendiente" deshabilitado cuando estado es "Finalizado"
* Mensajes informativos: verde (finalizado) y naranja (sin permisos)
* Requiere URL de GitHub al marcar como finalizado
* Visualización de responsable técnico, fecha y URL

## Archivos Modificados
* `backend/src/controllers/peticionCambioController.js`
* `backend/src/routes/peticionCambioRoutes.js`
* `src/pages/Admin/PeticionesCambioAdmin/PeticionesCambioAdmin.js`
* `backend/migrations/001_add_estado_issue.sql`

## Testing
- [x] Solo responsable técnico puede marcar como Finalizado
- [x] Estado Finalizado es inmutable
- [x] URL de GitHub requerida
- [x] Auditoría automática (fecha, usuario, URL)
- [x] Nombres completos en UI (no IDs)